### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,6 +2,9 @@ name: Testing
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   testing:
     environment:


### PR DESCRIPTION
Potential fix for [https://github.com/ezeparziale/fastapi-api-template/security/code-scanning/1](https://github.com/ezeparziale/fastapi-api-template/security/code-scanning/1)

Add an explicit `permissions` block to the workflow to enforce least privilege for `GITHUB_TOKEN`.  
Best fix here: define it at the workflow root (right after `on:`), so all jobs inherit it unless overridden.

For this file (`.github/workflows/testing.yml`), add:

- `permissions:`
  - `contents: read`

This preserves existing functionality (checkout and test execution) while removing reliance on potentially broad defaults.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
