### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,5 +1,7 @@
 name: lint_python
 on: [pull_request, push]
+permissions:
+  contents: read
 jobs:
   lint_python:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ezeparziale/fastapi-api-template/security/code-scanning/4](https://github.com/ezeparziale/fastapi-api-template/security/code-scanning/4)

Add an explicit `permissions` block to `.github/workflows/lint_python.yml` at the workflow root (right after `on:` is the cleanest location). For this lint/test workflow, `contents: read` is the minimal and appropriate permission, and it will apply to all jobs unless overridden. This does not change workflow functionality, only token scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
